### PR TITLE
travis: Add coveralls integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ setup.log
 
 api.docdir
 *.byte
+
+travis-coveralls.sh
+.coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: c
-install: wget https://raw.githubusercontent.com/johnelse/ocaml-travisci-skeleton/master/.travis-opam.sh
-script: PACKAGE=irc-client FORK_USER=johnelse bash -ex .travis-opam.sh
+install:
+  - wget https://raw.githubusercontent.com/johnelse/ocaml-travisci-skeleton/master/.travis-opam.sh
+  - wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/travis-coveralls.sh
+script: bash -ex .travis-opam.sh && bash -ex travis-coveralls.sh
 env:
-  - OCAML_VERSION=4.00
-  - OCAML_VERSION=4.01
+  global:
+  - PACKAGE=irc-client
+  - FORK_USER=johnelse
   - OCAML_VERSION=4.02

--- a/Makefile
+++ b/Makefile
@@ -45,3 +45,9 @@ reinstall: setup.ml
 clean:
 	ocamlbuild -clean
 	rm -f setup.data setup.log
+
+travis-coveralls.sh:
+	wget https://raw.githubusercontent.com/simonjbeaumont/ocaml-travis-coveralls/master/$@
+
+coverage: travis-coveralls.sh
+	bash $<

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 IRC client library, supporting Lwt and Unix blocking IO.
 
 [![Build status](https://travis-ci.org/johnelse/ocaml-irc-client.png?branch=master)](https://travis-ci.org/johnelse/ocaml-irc-client)
+[![Coverage Status](https://coveralls.io/repos/johnelse/ocaml-irc-client/badge.svg?branch=master)](https://coveralls.io/r/johnelse/ocaml-irc-client?branch=master)
 
 Build dependencies
 ------------------


### PR DESCRIPTION
For this to work you'll need to enable your repo on coveralls.io and then hit rebuild on the Travis job.

I added a `make coverage` target which runs quite happily:

```
$ make coverage
...[ snip ]...
Summary:
 - 'binding' points: 61/122 (50.00%)
 - 'sequence' points: 5/22 (22.73%)
 - 'for' points: none
 - 'if/then' points: 5/11 (45.45%)
 - 'try' points: 2/6 (33.33%)
 - 'while' points: none
 - 'match/function' points: 3/47 (6.38%)
 - 'class expression' points: none
 - 'class initializer' points: none
 - 'class method' points: none
 - 'class value' points: none
 - 'toplevel expression' points: none
 - 'lazy operator' points: 2/2 (100.00%)
 - total: 78/210 (37.14%)
/local/work/code/ocaml-irc-client
```

Signed-off-by: Si Beaumont <simon.beaumont@citrix.com>