### PR TITLE
Fix the README code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ messages in that channel to stdout:
 
 ```ocaml
 open Lwt
-module C = Irc_client_lwt.Client
+module C = Irc_client_lwt
 
 let host = "localhost"
 let port = 6667
@@ -37,17 +37,13 @@ let string_opt_to_string = function
 let string_list_to_string string_list =
   Printf.sprintf "[%s]" (String.concat "; " string_list)
 
-let callback ~connection ~result =
+let callback _connection result =
   let open Irc_message in
   match result with
-  | Message {prefix=prefix; command=command; params=params; trail=trail} ->
-    Lwt_io.printf "Got message: prefix=%s; command=%s; params=%s; trail=%s\n"
-      (string_opt_to_string prefix)
-      command
-      (string_list_to_string params)
-      (string_opt_to_string trail)
-  | Parse_error (raw, error) ->
-    Lwt_io.printf "Failed to parse \"%s\" because: %s" raw error
+  | `Ok msg ->
+    Lwt_io.printf "Got message: %s\n" (to_string msg)
+  | `Error e ->
+    Lwt_io.printl e
 
 let lwt_main =
   Lwt_unix.gethostbyname host


### PR DESCRIPTION
The README's example code no longer compiled with 0.3.0+. This pull request updates the example, drawing on `examples/example1.ml`.