### PR TITLE
answer to ping while establishing connection

### DIFF
--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -92,6 +92,9 @@ module Make(Io: Irc_transport.IO) = struct
         | `Ok {M.command = M.Other ("001", _); _} ->
           (* we received "RPL_WELCOME", i.e. 001 *)
           return ()
+        | `Ok {M.command = M.PING message; _} ->
+          (* server may ask for ping at any time *)
+          send_pong ~connection ~message >>= fun () -> wait_for_welcome ~connection
         | _ -> wait_for_welcome ~connection
 
 


### PR DESCRIPTION
I'm not exactly sure what the proper behaviour is, but currently, while the client is waiting for RPL_WELCOME, it ignores all other messages. I'm trying to connect to a server that sends a PING and expects a PONG before sending RPL_WELCOME.

Answering PINGs while waiting for a RPL_WELCOME seems harmless and solves my current problem.