### PR TITLE
Use bytes in the Io.read prototype

### DIFF
--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -13,7 +13,7 @@ module type IO = sig
   val open_socket : inet_addr -> int -> file_descr t
   val close_socket : file_descr -> unit t
 
-  val read : file_descr -> string -> int -> int -> int t
+  val read : file_descr -> Bytes.t -> int -> int -> int t
   val write : file_descr -> string -> int -> int -> int t
 
   val gethostbyname : string -> inet_addr list t


### PR DESCRIPTION
This is for -safe-string compatibility.