### PR TITLE
implement a `keepalive` argument in `Irc_client` (see #22)

### DIFF
--- a/examples/example1.ml
+++ b/examples/example1.ml
@@ -31,7 +31,7 @@ let lwt_main =
   >>= fun connection -> Lwt_io.printl "Connected"
   >>= fun () -> C.send_join ~connection ~channel
   >>= fun () -> C.send_privmsg ~connection ~target:channel ~message
-  >>= fun () -> C.listen ~connection ~callback
+  >>= fun () -> C.listen ?keepalive:None ~connection ~callback
   >>= fun () -> C.send_quit ~connection
 
 let _ = Lwt_main.run lwt_main

--- a/examples/example1.ml
+++ b/examples/example1.ml
@@ -31,7 +31,7 @@ let lwt_main =
   >>= fun connection -> Lwt_io.printl "Connected"
   >>= fun () -> C.send_join ~connection ~channel
   >>= fun () -> C.send_privmsg ~connection ~target:channel ~message
-  >>= fun () -> C.listen ?keepalive:None ~connection ~callback
+  >>= fun () -> C.listen ~connection ~callback ()
   >>= fun () -> C.send_quit ~connection
 
 let _ = Lwt_main.run lwt_main

--- a/examples/example2.ml
+++ b/examples/example2.ml
@@ -27,6 +27,7 @@ let callback connection result =
     Lwt_io.printl e
 
 let lwt_main =
+  C.set_log Lwt_io.printl;
   Lwt_io.printl "Connecting..."
   >>= fun () ->
   C.connect_by_name ~server:!host ~port:!port ~nick:!nick ()

--- a/examples/example2.ml
+++ b/examples/example2.ml
@@ -35,7 +35,7 @@ let lwt_main =
   | Some connection ->
   Lwt_io.printl "Connected"
   >>= fun () ->
-  let t = C.listen ~connection ~callback in
+  let t = C.listen ?keepalive:None ~connection ~callback in
   Lwt_io.printl "send join msg"
   >>= fun () -> C.send_join ~connection ~channel:!channel
   >>= fun () -> C.send_privmsg ~connection ~target:!channel ~message

--- a/lib/irc_client.mli
+++ b/lib/irc_client.mli
@@ -76,4 +76,7 @@ module Make : functor (Io: Irc_transport.IO) ->
         messages are passed, along with [connection], to [callback].
         @param keepalive the behavior on disconnection (if the transport
           supports {!Irc_transport.IO.pick} and {!Irc_transport.IO.sleep}) *)
+
+    val set_log : (string -> unit Io.t) -> unit
+    (** Set logging function *)
   end

--- a/lib/irc_client.mli
+++ b/lib/irc_client.mli
@@ -51,7 +51,20 @@ module Make : functor (Io: Irc_transport.IO) ->
         {!connect}. Returns [None] if no IP could be found for the given
         name. *)
 
-    val listen : connection:connection_t ->
+    (** Information on keeping the connection alive *)
+    type keepalive = {
+      mode: [`Active | `Passive];
+      timeout: int;
+      reconnect_delay: int option;
+      (* [Some t] means reconnect automatically after [t] seconds *)
+    }
+
+    val default_keepalive : keepalive
+    (** Default value for keepalive: active mode with auto-reconnect *)
+
+    val listen :
+      ?keepalive:keepalive ->
+      connection:connection_t ->
       callback:(
         connection_t ->
         Irc_message.parse_result ->
@@ -60,5 +73,7 @@ module Make : functor (Io: Irc_transport.IO) ->
       unit Io.t
     (** [listen connection callback] listens for incoming messages on
         [connection]. All server pings are handled internally; all other
-        messages are passed, along with [connection], to [callback]. *)
+        messages are passed, along with [connection], to [callback].
+        @param keepalive the behavior on disconnection (if the transport
+          supports {!Irc_transport.IO.pick} and {!Irc_transport.IO.sleep}) *)
   end

--- a/lib/irc_transport.ml
+++ b/lib/irc_transport.ml
@@ -17,6 +17,6 @@ module type IO = sig
 
   val iter : ('a -> unit t) -> 'a list -> unit t
 
-  val sleep : (float -> unit t) option
+  val sleep : int -> unit t
   val pick : ('a t list -> 'a t) option
 end

--- a/lib/irc_transport.ml
+++ b/lib/irc_transport.ml
@@ -13,6 +13,8 @@ module type IO = sig
   val read : file_descr -> Bytes.t -> int -> int -> int t
   val write : file_descr -> Bytes.t -> int -> int -> int t
 
+  val read_with_timeout : timeout:int -> file_descr -> Bytes.t -> int -> int -> int option t
+
   val gethostbyname : string -> inet_addr list t
 
   val iter : ('a -> unit t) -> 'a list -> unit t

--- a/lib/irc_transport.ml
+++ b/lib/irc_transport.ml
@@ -16,4 +16,7 @@ module type IO = sig
   val gethostbyname : string -> inet_addr list t
 
   val iter : ('a -> unit t) -> 'a list -> unit t
+
+  val sleep : (float -> unit t) option
+  val pick : ('a t list -> 'a t) option
 end

--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -21,4 +21,13 @@ module type IO = sig
       list if none is found) *)
 
   val iter : ('a -> unit t) -> 'a list -> unit t
+
+  val sleep : (float -> unit t) option
+  (** OPTIONAL
+      [sleep t] starts a thread that sleeps for [t] seconds, then returns. *)
+
+  val pick : ('a t list -> 'a t) option
+  (** OPTIONAL
+      [pick l] returns the first  thread of [l] that terminates (and might
+      cancel the others) *)
 end

--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -16,6 +16,11 @@ module type IO = sig
   val read : file_descr -> Bytes.t -> int -> int -> int t
   val write : file_descr -> Bytes.t -> int -> int -> int t
 
+  val read_with_timeout : timeout:int -> file_descr -> Bytes.t -> int -> int -> int option t
+  (** [read_with_timeout ~timeout fd buf off len] returns [Some n] if it
+      could read [n] bytes into [buf] (slice [off,...,off+len-1]),
+      or [None] if nothing was read before [timeout] seconds. *)
+
   val gethostbyname : string -> inet_addr list t
   (** List of IPs that correspond to the given hostname (or an empty
       list if none is found) *)

--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -22,9 +22,8 @@ module type IO = sig
 
   val iter : ('a -> unit t) -> 'a list -> unit t
 
-  val sleep : (float -> unit t) option
-  (** OPTIONAL
-      [sleep t] starts a thread that sleeps for [t] seconds, then returns. *)
+  val sleep : int -> unit t
+  (* [sleep t] sleeps for [t] seconds, then returns. *)
 
   val pick : ('a t list -> 'a t) option
   (** OPTIONAL

--- a/lwt/irc_client_lwt.ml
+++ b/lwt/irc_client_lwt.ml
@@ -18,6 +18,13 @@ module Io = struct
   let read = Lwt_unix.read
   let write = Lwt_unix.write
 
+  let read_with_timeout ~timeout fd buf off len =
+    let open Lwt.Infix in
+    Lwt.pick
+      [ (read fd buf off len >|= fun i -> Some i);
+        (Lwt_unix.sleep (float timeout) >|= fun () -> None);
+      ]
+
   let gethostbyname name =
     Lwt.catch
       (fun () ->

--- a/lwt/irc_client_lwt.ml
+++ b/lwt/irc_client_lwt.ml
@@ -30,9 +30,9 @@ module Io = struct
       )
 
   let iter = Lwt_list.iter_s
+  let sleep d = Lwt_unix.sleep (float d)
 
   let pick = Some Lwt.pick
-  let sleep = Some Lwt_unix.sleep
 end
 
 include Irc_client.Make(Io)

--- a/lwt/irc_client_lwt.ml
+++ b/lwt/irc_client_lwt.ml
@@ -30,6 +30,9 @@ module Io = struct
       )
 
   let iter = Lwt_list.iter_s
+
+  let pick = Some Lwt.pick
+  let sleep = Some Lwt_unix.sleep
 end
 
 include Irc_client.Make(Io)

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -26,9 +26,9 @@ module Io = struct
       []
 
   let iter = List.iter
+  let sleep = Unix.sleep
 
   let pick = None
-  let sleep = None
 end
 
 include Irc_client.Make(Io)

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -26,6 +26,9 @@ module Io = struct
       []
 
   let iter = List.iter
+
+  let pick = None
+  let sleep = None
 end
 
 include Irc_client.Make(Io)

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -18,6 +18,12 @@ module Io = struct
   let read = Unix.read
   let write = Unix.write
 
+  let read_with_timeout ~timeout fd buf off len =
+    match Unix.select [fd] [] [] (float timeout) with
+      | [fd], _, _ -> Some (Unix.read fd buf off len)
+      | [], _, _ -> None
+      | _ -> assert false
+
   let gethostbyname name =
     try
       let entry = Unix.gethostbyname name in


### PR DESCRIPTION
Should solve most issues with #22 

I have not tested it thoroughly yet, though. Side note: it would be useful to have a "log" function somewhere (defaulting to not logging, but swappable by the user).

The biggest design issue is how to deal with the `Unix` backend since, so far, it did not require any real concurrency, which is at odds with the whole timeout+send ping in the background idea.