### PR TITLE
use `Unix.time` for timeouts

### DIFF
--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -119,7 +119,8 @@ module Make(Io: Irc_transport.IO) = struct
   let log_ : (string -> unit Io.t) ref = ref (fun _ -> Io.return ())
   let set_log f = log_ := f
 
-  let log s = !log_ (Printf.sprintf "[%.2f] %s" (Io.time ()) s)
+  let start_time = Io.time()
+  let log s = !log_ (Printf.sprintf "[%.2f] %s" (Io.time () -. start_time) s)
   let logf s = Printf.ksprintf log s
 
   open Io

--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -298,7 +298,7 @@ module Make(Io: Irc_transport.IO) = struct
     (* main loop *)
     let rec listen_rec state =
       let now = Io.time() in
-      let timeout = state.last_seen +. float keepalive.timeout -. Io.time () in
+      let timeout = state.last_seen +. float keepalive.timeout -. now in
       next_line_ ~timeout:(int_of_float (ceil timeout)) ~connection
       >>= function
       | Timeout ->

--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -119,7 +119,7 @@ module Make(Io: Irc_transport.IO) = struct
   let log_ : (string -> unit Io.t) ref = ref (fun _ -> Io.return ())
   let set_log f = log_ := f
 
-  let log s = !log_ (Printf.sprintf "[%.2f] %s" (Sys.time()) s)
+  let log s = !log_ (Printf.sprintf "[%.2f] %s" (Io.time ()) s)
   let logf s = Printf.ksprintf log s
 
   open Io
@@ -270,7 +270,7 @@ module Make(Io: Irc_transport.IO) = struct
   let active_ping_thread keepalive state ~connection =
     let rec loop () =
       assert (keepalive.mode = `Active);
-      let now = Sys.time() in
+      let now = Io.time () in
       let time_til_ping =
         state.last_active_ping +. float keepalive.timeout -. now
       in
@@ -296,8 +296,8 @@ module Make(Io: Irc_transport.IO) = struct
   let listen ?(keepalive=default_keepalive) ~connection ~callback () =
     (* main loop *)
     let rec listen_rec state =
-      let now = Sys.time() in
-      let timeout = state.last_seen +. float keepalive.timeout -. Sys.time () in
+      let now = Io.time() in
+      let timeout = state.last_seen +. float keepalive.timeout -. Io.time () in
       next_line_ ~timeout:(int_of_float (ceil timeout)) ~connection
       >>= function
       | Timeout ->
@@ -326,8 +326,8 @@ module Make(Io: Irc_transport.IO) = struct
         else listen_rec state
     in
     let state = {
-      last_seen = Sys.time();
-      last_active_ping = Sys.time();
+      last_seen = Io.time();
+      last_active_ping = Io.time();
       finished = false;
     } in
     (* connect, serve, etc. *)

--- a/lib/irc_transport.ml
+++ b/lib/irc_transport.ml
@@ -22,5 +22,6 @@ module type IO = sig
   val iter : ('a -> unit t) -> 'a list -> unit t
 
   val sleep : int -> unit t
+  val time : unit -> float
   val pick : ('a t list -> 'a t) option
 end

--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -35,6 +35,10 @@ module type IO = sig
   val sleep : int -> unit t
   (* [sleep t] sleeps for [t] seconds, then returns. *)
 
+  val time : unit -> float
+  (** Current wall time (used for timeouts). Typically, {!Unix.time}.
+      @since NEXT_RELEASE *)
+
   val pick : ('a t list -> 'a t) option
   (** OPTIONAL
       [pick l] returns the first  thread of [l] that terminates (and might

--- a/lwt/irc_client_lwt.ml
+++ b/lwt/irc_client_lwt.ml
@@ -38,6 +38,7 @@ module Io_lwt = struct
 
   let iter = Lwt_list.iter_s
   let sleep d = Lwt_unix.sleep (float d)
+  let time = Unix.time
 
   let pick = Some Lwt.pick
 end

--- a/tls/irc_client_tls.ml
+++ b/tls/irc_client_tls.ml
@@ -41,6 +41,7 @@ module Io_tls = struct
 
   let iter = Lwt_list.iter_s
   let sleep d = Lwt_unix.sleep (float d)
+  let time = Unix.time
 
   let pick = Some Lwt.pick
 end

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -33,6 +33,7 @@ module Io_unix = struct
 
   let iter = List.iter
   let sleep = Unix.sleep
+  let time = Unix.time
 
   let pick = None
 end


### PR DESCRIPTION
As reported on IRC, the usage of `Sys.time()` to measure time for timeouts is totally wrong (don't know what got into my mind). Here is a fix that requires a `time` function in the `Irc_transport` (typically, `Unix.time`, but might also use `mtime` or `oclock` for ultimate precision‽).