### PR TITLE
Fix cancelled exn

### DIFF
--- a/lib/irc_transport.ml
+++ b/lib/irc_transport.ml
@@ -20,6 +20,7 @@ module type IO = sig
   val gethostbyname : string -> inet_addr list t
 
   val iter : ('a -> unit t) -> 'a list -> unit t
+  val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
 
   val sleep : int -> unit t
   val time : unit -> float

--- a/lib/irc_transport.mli
+++ b/lib/irc_transport.mli
@@ -32,6 +32,10 @@ module type IO = sig
 
   val iter : ('a -> unit t) -> 'a list -> unit t
 
+  val catch : (unit -> 'a t) -> (exn -> 'a t) -> 'a t
+  (** Catch asynchronous exception
+      @since NEXT_RELEASE *)
+
   val sleep : int -> unit t
   (* [sleep t] sleeps for [t] seconds, then returns. *)
 

--- a/lwt/irc_client_lwt.ml
+++ b/lwt/irc_client_lwt.ml
@@ -38,6 +38,7 @@ module Io_lwt = struct
 
   let iter = Lwt_list.iter_s
   let sleep d = Lwt_unix.sleep (float d)
+  let catch = Lwt.catch
   let time = Unix.time
 
   let pick = Some Lwt.pick

--- a/tls/irc_client_tls.ml
+++ b/tls/irc_client_tls.ml
@@ -41,6 +41,7 @@ module Io_tls = struct
 
   let iter = Lwt_list.iter_s
   let sleep d = Lwt_unix.sleep (float d)
+  let catch = Lwt.catch
   let time = Unix.time
 
   let pick = Some Lwt.pick

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -33,6 +33,7 @@ module Io_unix = struct
 
   let iter = List.iter
   let sleep = Unix.sleep
+  let catch f g = try f () with e -> g e
   let time = Unix.time
 
   let pick = None


### PR DESCRIPTION
Sometimes, exceptions would occur and kill the main loop.

To test this change:

```sh
$ ./example_tls.byte -host chat.freenode.net -port 7000 -chan '#test123'
#[… wait for bot to connect …]
$ ctrl-z
#[… wait some time (1 minute?) …]
$ fg
#[… bot should try and reconnect, but die of uncaught `Lwt.Cancelled` with old version …]
```

I suspect some operations would fail because of the use of `Lwt.pick`, but they would fail at weird places because of all the hidden blocking operations in `send_ping`, `send_pong`, etc.