### PR TITLE
Improve active ping mode.

### DIFF
--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -273,7 +273,8 @@ module Make(Io: Irc_transport.IO) = struct
       assert (keepalive.mode = `Active);
       let now = Io.time () in
       let time_til_ping =
-        state.last_active_ping +. float keepalive.timeout -. now
+        (max state.last_active_ping state.last_seen)
+        +. float keepalive.timeout -. now
       in
       if state.finished then (
         Io.return ()

--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -274,7 +274,7 @@ module Make(Io: Irc_transport.IO) = struct
       let now = Io.time () in
       let time_til_ping =
         (max state.last_active_ping state.last_seen)
-        +. float keepalive.timeout -. now
+        +. (float keepalive.timeout /. 2.) -. now
       in
       if state.finished then (
         Io.return ()

--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -288,9 +288,9 @@ module Make(Io: Irc_transport.IO) = struct
         )
           >>= fun () ->
           (* sleep until the due date, then check again *)
-          Io.sleep (int_of_float time_til_ping + 1) >>= fun () ->
-          loop ()
+          Io.sleep (int_of_float time_til_ping + 1)
       )
+      >>= fun () -> loop ()
     in
     loop ()
 


### PR DESCRIPTION
It fixes an issue where the active_ping_thread exited immediately after sending a ping.
It also changes the time after which a ping is sent. It now waits half of the specified timeout after the last ping or the last message received by the server to send a ping.