### PR TITLE
Quick pong message fix (1->2 params).

### DIFF
--- a/lib/irc_client.ml
+++ b/lib/irc_client.ml
@@ -156,7 +156,7 @@ module Make(Io: Irc_transport.IO) = struct
     send ~connection (M.ping message)
 
   let send_pong ~connection ~message =
-    send ~connection (M.pong message)
+    send ~connection (M.pong ~middle:"ocaml-irc-client" ~trailer:message)
 
   let send_privmsg ~connection ~target ~message =
     send ~connection (M.privmsg ~target message)

--- a/lib/irc_message.ml
+++ b/lib/irc_message.ml
@@ -19,7 +19,7 @@ type command =
   | PRIVMSG of string * string (** target * message *)
   | NOTICE of string * string (** target * message *)
   | PING of string
-  | PONG of string
+  | PONG of string * string
   | Other of string * (string list) (** command name * parameters *)
 
 type t = {
@@ -49,7 +49,7 @@ let kick ~chans ~nick ~comment = make_ (KICK (chans, nick, unwrap_ "" comment))
 let privmsg ~target msg = make_ (PRIVMSG (target, msg))
 let notice ~target msg = make_ (NOTICE (target, msg))
 let ping s = make_ (PING s)
-let pong s = make_ (PONG s)
+let pong ~middle ~trailer = make_ (PONG (middle, trailer))
 
 let other ~cmd ~params = make_other_ cmd params
 
@@ -163,7 +163,9 @@ let parse_exn msg =
         let target, msg = expect2 msg params in
         NOTICE (target, msg)
       | "PING" -> PING (expect1 msg params)
-      | "PONG" -> PONG (expect1 msg params)
+      | "PONG" ->
+        let middle, trailer = expect1or2 msg params in
+        PONG (middle, trailer)
       | other -> Other (other, params)
     in
     { prefix; command }
@@ -216,7 +218,7 @@ let write_cmd_buf buf t =
   | PRIVMSG (a,b) -> pp "PRIVMSG %s %a" a write_trail b
   | NOTICE (a,b) -> pp "NOTICE %s %a" a write_trail b
   | PING a -> pp "PING %a" write_trail a
-  | PONG a -> pp "PONG %a" write_trail a
+  | PONG (a,b) -> pp "PONG %s %a" a write_trail b
   | Other (command_name, params) ->
     Printf.bprintf buf "%s %a" command_name (write_list ~trail:true ' ') params
 

--- a/lib/irc_message.mli
+++ b/lib/irc_message.mli
@@ -21,7 +21,7 @@ type command =
   | PRIVMSG of string * string (** target * message *)
   | NOTICE of string * string (** target * message *)
   | PING of string
-  | PONG of string
+  | PONG of string * string
   | Other of string * string list  (** other cases *)
 
 type t = {
@@ -48,7 +48,7 @@ val kick : chans:string list -> nick:string -> comment:string option -> t
 val privmsg : target:string -> string -> t
 val notice : target:string -> string -> t
 val ping : string -> t
-val pong : string -> t
+val pong : middle:string -> trailer:string -> t
 
 val other : cmd:string -> params:string list -> t
 


### PR DESCRIPTION
Most servers will send the server name as first parameter of PONG and
the first parameter of the corresponding PING as second parameter.

This quick fix adds a second parameter and sets the first one to a
hardcoded string "ocaml-irc-client".

Fixes #38 