### PR TITLE
add a new optional parameter to reconnect_loop

### DIFF
--- a/lib/irc_client.mli
+++ b/lib/irc_client.mli
@@ -84,6 +84,7 @@ module type CLIENT = sig
 
   val reconnect_loop :
     ?keepalive:keepalive ->
+    ?reconnect:bool ->
     after:int ->
     connect:(unit -> connection_t option Io.t) ->
     f:(connection_t -> unit Io.t) ->

--- a/unix/irc_client_unix.ml
+++ b/unix/irc_client_unix.ml
@@ -48,5 +48,5 @@ let default_keepalive = {mode=`Passive; timeout=300}
 let listen ?(keepalive=default_keepalive) ~connection ~callback () =
   listen ~keepalive ~connection ~callback ()
 
-let reconnect_loop ?(keepalive=default_keepalive) ~after ~connect ~f ~callback () =
-  reconnect_loop ~keepalive ~after ~connect ~f ~callback ()
+let reconnect_loop ?(keepalive=default_keepalive) ?(reconnect=true) ~after ~connect ~f ~callback () =
+  reconnect_loop ~keepalive ~reconnect ~after ~connect ~f ~callback ()


### PR DESCRIPTION
The new parameter "reconnect" is a boolean which is true by default. It
express the fact that the bot try to reconnect or not after the listen loop
end without exception.