### PR TITLE
Prefix with ':' if message starts with ':'

### DIFF
--- a/src/core/irc_message.ml
+++ b/src/core/irc_message.ml
@@ -183,7 +183,8 @@ let parse s =
 
 (* write [s] into [buf], possibly as a ':'-prefixed trail *)
 let write_trail buf s =
-  if String.contains s ' ' then Buffer.add_char buf ':';
+  if String.contains s ' ' || String.length s > 0 && s.[0] = ':'
+  then Buffer.add_char buf ':';
   Buffer.add_string buf s
 
 (* output list to buffer *)


### PR DESCRIPTION
This allows the client to send messages like ":D" etc. without losing the eyes.

:D