### PR TITLE
Remove dead code from examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ let username = nick
 let channel = "#demo_irc"
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
-let string_opt_to_string = function
-  | None -> "None"
-  | Some s -> Printf.sprintf "Some %s" s
-
-let string_list_to_string string_list =
-  Printf.sprintf "[%s]" (String.concat "; " string_list)
-
 let callback _connection result =
   let open Irc_message in
   match result with

--- a/examples/example1.ml
+++ b/examples/example1.ml
@@ -9,13 +9,6 @@ let username = nick
 let channel = "#demo_irc"
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
-let string_opt_to_string = function
-  | None -> "None"
-  | Some s -> Printf.sprintf "Some %s" s
-
-let string_list_to_string string_list =
-  Printf.sprintf "[%s]" (String.concat "; " string_list)
-
 let callback _connection result =
   let open Irc_message in
   match result with

--- a/examples/example2.ml
+++ b/examples/example2.ml
@@ -8,9 +8,6 @@ let nick = ref "bobobobot"
 let channel = ref "#demo_irc"
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
-let string_list_to_string string_list =
-  Printf.sprintf "[%s]" (String.concat "; " string_list)
-
 let callback connection result =
   match result with
   | Result.Ok ({M.command=M.Other _ ; _}as msg) ->

--- a/examples/example2_unix.ml
+++ b/examples/example2_unix.ml
@@ -7,9 +7,6 @@ let nick = ref "bobobobot"
 let channel = ref "#demo_irc"
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
-let string_list_to_string string_list =
-  Printf.sprintf "[%s]" (String.concat "; " string_list)
-
 let callback connection result =
   match result with
   | Result.Ok ({M.command=M.Other _ ; _}as msg) ->

--- a/examples/example_tls.ml
+++ b/examples/example_tls.ml
@@ -8,9 +8,6 @@ let nick = ref "bobobobot"
 let channel = ref "#demo_irc"
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
-let string_list_to_string string_list =
-  Printf.sprintf "[%s]" (String.concat "; " string_list)
-
 let callback connection result =
   match result with
   | Result.Ok ({M.command=M.Other _ ; _}as msg) ->


### PR DESCRIPTION
The functions `string_opt_to_string` and `string_list_to_string` were defined but unused in the examples.