### PR TITLE
Add support for x509 0.10.0

### DIFF
--- a/irc-client-tls.opam
+++ b/irc-client-tls.opam
@@ -15,6 +15,7 @@ depends: [
   "irc-client"
   "lwt"
   "tls"
+  "x509" {>= "0.10.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.02.0" }
 ]

--- a/src/tls/irc_client_tls.ml
+++ b/src/tls/irc_client_tls.ml
@@ -15,7 +15,7 @@ module Io_tls = struct
   type config = Tls.Config.client
 
   let default_config : Tls.Config.client =
-    Tls.Config.client ~authenticator:X509.Authenticator.null ()
+    Tls.Config.client ~authenticator:(fun ~host:_ _ -> Ok None) ()
 
   let open_socket ?(config=default_config) addr port : file_descr t =
     Tls_lwt.connect_ext config (addr,port) >|= fun (ic,oc) ->


### PR DESCRIPTION
As a side-effect, this brings the OCaml 4.12 support to irc-client.