### PR TITLE
add `logs` and basic SASL authentication

### DIFF
--- a/examples/example_lwt_ssl.ml
+++ b/examples/example_lwt_ssl.ml
@@ -52,6 +52,7 @@ let options = Arg.align
   [ "-host", Arg.Set_string host, " set remove server host name"
   ; "-port", Arg.Set_int port, " set remote server port"
   ; "-chan", Arg.Set_string channel, " channel to join"
+  ; "-nick", Arg.Set_string nick, " nickname"
   ; "-check", Arg.Set check_certif, " check certificate"
   ; "-no-check", Arg.Clear check_certif, " do not check certificate"
   ; "-debug", Arg.Set debug, " enable debug"

--- a/examples/example_lwt_ssl.ml
+++ b/examples/example_lwt_ssl.ml
@@ -2,11 +2,12 @@ open Lwt
 module C = Irc_client_lwt_ssl
 module M = Irc_message
 
-let host = ref "irc.freenode.net"
+let host = ref "irc.libera.chat"
 let port = ref 6697
 let nick = ref "bobobobot"
 let channel = ref "#demo_irc"
 let check_certif = ref false
+let debug = ref false
 let message = "Hello, world!  This is a test from ocaml-irc-client"
 
 let callback connection result =
@@ -26,12 +27,17 @@ let callback connection result =
 
 let lwt_main () =
   let config = C.Config.({default with check_certificate= !check_certif}) in
-  C.set_log Lwt_io.printl;
+  let username, password, sasl =
+    match Sys.getenv "USER", Sys.getenv "PASSWORD" with
+    | u, p -> u, Some p, true
+    | exception _ -> "ocaml-irc-client", None, false
+  in
   C.reconnect_loop
     ~after:30
     ~connect:(fun () ->
       Lwt_io.printl "Connecting..." >>= fun () ->
-      C.connect_by_name ~config ~server:!host ~port:!port ~nick:!nick ()
+      C.connect_by_name ~config ~username ?password ~sasl
+        ~server:!host ~port:!port ~nick:!nick ()
     )
     ~f:(fun connection ->
       Lwt_io.printl "Connected" >>= fun () ->
@@ -48,10 +54,14 @@ let options = Arg.align
   ; "-chan", Arg.Set_string channel, " channel to join"
   ; "-check", Arg.Set check_certif, " check certificate"
   ; "-no-check", Arg.Clear check_certif, " do not check certificate"
+  ; "-debug", Arg.Set debug, " enable debug"
   ]
 
-let _ =
-  Arg.parse options (fun _ -> ()) "example2 [options]";
+let () =
+  Logs.set_reporter (Logs.format_reporter());
+  Arg.parse options (fun _ -> ())
+    "example.exe [options]\nif USER and PASSWORD env vars are set, uses SASL authentication";
+  Logs.set_level ~all:true (Some (if !debug then Logs.Debug else Logs.Info));
   Lwt_main.run
     (Lwt.catch
        lwt_main

--- a/irc-client.opam
+++ b/irc-client.opam
@@ -14,6 +14,7 @@ depends: [
   "dune" {>= "1.6"}
   "base-bytes"
   "result"
+  "logs"
   "ounit" {with-test}
   "odoc" {with-doc}
   "ocaml" { >= "4.02.0" }

--- a/irc-client.opam
+++ b/irc-client.opam
@@ -15,6 +15,7 @@ depends: [
   "base-bytes"
   "result"
   "logs"
+  "base64"
   "ounit" {with-test}
   "odoc" {with-doc}
   "ocaml" { >= "4.02.0" }

--- a/irc-client.opam
+++ b/irc-client.opam
@@ -15,7 +15,7 @@ depends: [
   "base-bytes"
   "result"
   "logs"
-  "base64"
+  "base64" {>= "3.0.0"}
   "ounit" {with-test}
   "odoc" {with-doc}
   "ocaml" { >= "4.02.0" }

--- a/src/core/dune
+++ b/src/core/dune
@@ -2,4 +2,4 @@
   (name irc_client)
   (public_name irc-client)
   (wrapped false)
-  (libraries result bytes))
+  (libraries result bytes logs))

--- a/src/core/dune
+++ b/src/core/dune
@@ -2,4 +2,4 @@
   (name irc_client)
   (public_name irc-client)
   (wrapped false)
-  (libraries result bytes logs))
+  (libraries result bytes logs base64))

--- a/src/core/irc_client.ml
+++ b/src/core/irc_client.ml
@@ -144,7 +144,7 @@ module Make(Io: Irc_transport.IO) = struct
 
   let send_auth_sasl ~connection ~user ~password =
     Log.debug (fun k->k"login using SASL with user=%S" user);
-    send_raw ~connection ~data:"CAP REQ sasl=plain" >>= fun () ->
+    send_raw ~connection ~data:"CAP REQ :sasl" >>= fun () ->
     send_raw ~connection ~data:"AUTHENTICATE PLAIN" >>= fun () ->
     let b64_login =
       Base64.encode_string @@
@@ -241,6 +241,7 @@ module Make(Io: Irc_transport.IO) = struct
           | Timeout
           | End -> return ()
           | Read line ->
+            Log.debug (fun k->k"read: %s" line);
             begin match M.parse line with
               | Result.Ok {M.command = M.Other ("001", _); _} ->
                 (* we received "RPL_WELCOME", i.e. 001 *)

--- a/src/core/irc_client.mli
+++ b/src/core/irc_client.mli
@@ -102,9 +102,6 @@ module type CLIENT = sig
         (a closure over {!connect} or {!connect_by_name})
       @param callback the callback for {!listen}
       @param f the function to call after connection *)
-
-  val set_log : (string -> unit Io.t) -> unit
-  (** Set logging function *)
 end
 
 module Make : functor (Io: Irc_transport.IO) ->

--- a/src/core/irc_client.mli
+++ b/src/core/irc_client.mli
@@ -43,20 +43,25 @@ module type CLIENT = sig
 
   val connect :
     ?username:string -> ?mode:int -> ?realname:string -> ?password:string ->
-    ?config:Io.config ->
+    ?sasl:bool -> ?config:Io.config ->
     addr:Io.inet_addr -> port:int -> nick:string -> unit ->
     connection_t Io.t
   (** Connect to an IRC server at address [addr]. The PASS command will be
-      sent if [password] is not None. *)
+      sent if [password] is not None and if [sasl] is [false].
+      @param sasl if true, try to use SASL (plain) authentication with the server.
+        This is an IRCv3 extension and might not be supported everywhere; it
+        might also require a secure transport (see {!Irc_client_lwt_ssl}
+        or {!Irc_client_tls} for example). This param exists @since 0.7.
+  *)
 
   val connect_by_name :
     ?username:string -> ?mode:int -> ?realname:string -> ?password:string ->
-    ?config:Io.config ->
+    ?sasl:bool -> ?config:Io.config ->
     server:string -> port:int -> nick:string -> unit ->
     connection_t option Io.t
   (** Try to resolve the [server] name using DNS, otherwise behaves like
       {!connect}. Returns [None] if no IP could be found for the given
-      name. *)
+      name. See {!connect} for more details. *)
 
   (** Information on keeping the connection alive *)
   type keepalive = {

--- a/src/core/irc_helpers.ml
+++ b/src/core/irc_helpers.ml
@@ -45,3 +45,4 @@ let handle_input ~buffer ~input =
   (* Return the whole lines extracted from the buffer. *)
   whole_lines
 
+module Log = (val Logs.src_log (Logs.Src.create ~doc:"irc-client low level logging" "irc-client"))

--- a/src/core/irc_helpers.mli
+++ b/src/core/irc_helpers.mli
@@ -12,3 +12,4 @@ val handle_input : buffer:Buffer.t -> input:string -> string list
     return all whole lines present in the buffer, and reinitialise the buffer to
     contain only the substring which follows all the whole lines. *)
 
+module Log : Logs.LOG

--- a/src/core/irc_transport.ml
+++ b/src/core/irc_transport.ml
@@ -1,6 +1,7 @@
 module type IO = sig
   type 'a t
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+  val (>|=) : 'a t -> ('a -> 'b) -> 'b t
   val return : 'a -> 'a t
 
   type file_descr

--- a/src/core/irc_transport.mli
+++ b/src/core/irc_transport.mli
@@ -4,6 +4,7 @@
 module type IO = sig
   type 'a t
   val (>>=) : 'a t -> ('a -> 'b t) -> 'b t
+  val (>|=) : 'a t -> ('a -> 'b) -> 'b t
   val return : 'a -> 'a t
 
   type file_descr

--- a/src/lwt/irc_client_lwt.ml
+++ b/src/lwt/irc_client_lwt.ml
@@ -1,6 +1,7 @@
 module Io_lwt = struct
   type 'a t = 'a Lwt.t
   let (>>=) = Lwt.bind
+  let (>|=) = Lwt.(>|=)
   let return = Lwt.return
 
   type file_descr = Lwt_unix.file_descr

--- a/src/lwt_ssl/irc_client_lwt_ssl.ml
+++ b/src/lwt_ssl/irc_client_lwt_ssl.ml
@@ -11,6 +11,7 @@ end
 module Io_lwt_ssl = struct
   type 'a t = 'a Lwt.t
   let (>>=) = Lwt.bind
+  let (>|=) = Lwt.(>|=)
   let return = Lwt.return
 
   type file_descr = {

--- a/src/lwt_ssl/irc_client_lwt_ssl.ml
+++ b/src/lwt_ssl/irc_client_lwt_ssl.ml
@@ -27,6 +27,7 @@ module Io_lwt_ssl = struct
       (* from https://github.com/johnelse/ocaml-irc-client/pull/21 *)
       Ssl.set_verify_depth ssl 3;
       Ssl.set_verify ssl [Ssl.Verify_peer] (Some Ssl.client_verify_callback);
+      Ssl.set_client_verify_callback_verbose true;
     end;
     let sock = Lwt_unix.socket Lwt_unix.PF_INET Lwt_unix.SOCK_STREAM 0 in
     let sockaddr = Lwt_unix.ADDR_INET (addr, port) in

--- a/src/tls/irc_client_tls.ml
+++ b/src/tls/irc_client_tls.ml
@@ -3,6 +3,7 @@ open Lwt.Infix
 module Io_tls = struct
   type 'a t = 'a Lwt.t
   let (>>=) = Lwt.bind
+  let (>|=) = Lwt.(>|=)
   let return = Lwt.return
 
   type file_descr = {

--- a/src/unix/irc_client_unix.ml
+++ b/src/unix/irc_client_unix.ml
@@ -1,6 +1,7 @@
 module Io_unix = struct
   type 'a t = 'a
   let (>>=) x f = f x
+  let (>|=) x f = f x
   let return x = x
 
   type file_descr = Unix.file_descr


### PR DESCRIPTION
close #56 and allows bots to log into irc.libera.chat from some servers (e.g. on digital ocean).