### PR TITLE
Stop reconnection loop on Exit.

### DIFF
--- a/src/core/irc_client.ml
+++ b/src/core/irc_client.ml
@@ -409,9 +409,13 @@ module Make(Io: Irc_transport.IO) = struct
              listen ?keepalive ~connection ~callback () >>= fun () ->
              Log.info (fun k->k"connection terminated.");
              return reconnect)
-        (fun e ->
-           Log.err (fun k->k"reconnect_loop: exception %s" (Printexc.to_string e));
-           return true)
+        (function
+          | Exit ->
+            Log.info (fun k->k"stopping the connection loop");
+            return false
+          | e ->
+            Log.err (fun k->k"reconnect_loop: exception %s" (Printexc.to_string e));
+            return true)
       >>= fun loop ->
       (* wait and reconnect *)
       Io.sleep after >>= fun () ->

--- a/src/core/irc_client.mli
+++ b/src/core/irc_client.mli
@@ -101,7 +101,8 @@ module type CLIENT = sig
     unit Io.t
   (** A combination of {!connect} and {!listen} that, every time
       the connection is terminated, tries to start a new one
-      after [after] seconds.
+      after [after] seconds. It stops reconnecting if the exception
+      [Exit] is raised.
       @param after time before trying to reconnect
       @param connect how to reconnect
         (a closure over {!connect} or {!connect_by_name})


### PR DESCRIPTION
There is currently no way of stopping the reconnection loop (`reconnect_loop`) when `reconnect` is set. I propose to allow the use of the `Exit` exception in order to stop it.