### PR TITLE
tls.lwt is now tls-lwt

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Unreleased
+* tls.lwt is now tls-lwt
+
 0.7.0 (15-Jun-2021):
  * Switch CI to github actions
  * Add support for SASL authentication

--- a/irc-client-tls.opam
+++ b/irc-client-tls.opam
@@ -14,7 +14,7 @@ depends: [
   "dune" {>= "1.6"}
   "irc-client"
   "lwt"
-  "tls" {>= "0.15.0"}
+  "tls-lwt" {>= "0.16.0"}
   "odoc" {with-doc}
   "ocaml" { >= "4.02.0" }
 ]

--- a/src/tls/dune
+++ b/src/tls/dune
@@ -1,5 +1,5 @@
 (library
-  (name irc_client_tls)
-  (public_name irc-client-tls)
-  (wrapped false)
-  (libraries result bytes irc-client lwt lwt.unix tls tls.lwt))
+ (name irc_client_tls)
+ (public_name irc-client-tls)
+ (wrapped false)
+ (libraries result bytes irc-client lwt lwt.unix tls tls-lwt))


### PR DESCRIPTION
will be needed due to changes here [ocaml/opam-repository#23311](https://github.com/ocaml/opam-repository/pull/23311)